### PR TITLE
[WIP] Manually manage installed versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: ruby
+language: C
 
 sudo: false
 


### PR DESCRIPTION
I've noticed that our Travis builders are very slow to start up on this project in comparison to hypothesis-python and am testing a hypothesis (so to speak) that this is because of "language: ruby".

If this works I'll set up something that uses [ruby-build](https://github.com/rbenv/ruby-build/) similarly to how we use pyenv in hypothesis-python to manage a ruby install for us.