### PR TITLE
Initial basic shrinker implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,11 @@ Documentation:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Lint/RescueException:
+  Enabled: false

--- a/AWFUL-HACKS.md
+++ b/AWFUL-HACKS.md
@@ -1,0 +1,85 @@
+# A Series of Unfortunate Implementation Choices
+
+## In Which The Narrator Seeks To Justify Himself
+
+This project is currently in a somewhat expeditionary state,
+where its goal is not to produce wonderful software that will
+stand the test of time, but instead to prove its concept
+valid and get something working enough for me to decide
+whether it's worth it to continue down this route, and
+to decide whether it's worth it to continue funding it.
+
+As such, whenever presented with the question "Do we want it
+good or do we want it soon?" I am mostly choosing soon.
+
+BUT I am optimistic about the long-term viability of this
+project, and I do not wish to find future-David cursing the
+very name of past-David. In aid of squaring this particular
+circle, I am choosing to document every terrible thing that
+I knowingly do.
+
+The goals of this documentation are:
+
+* To make me feel bad, so that I'm less likely to do things
+  that are awful but not actually needed.
+* To explain the reasoning to future-me and those who come
+  after.
+* To make explicit the conditions under which the awful hack
+  may be removed.
+
+## Awful Hacks
+
+### Panicky Clones
+
+Engine is currently set up to implement Clone but to panic when
+you call it.
+
+This is because [Helix seems to needlessly derive the Clone
+trait](https://github.com/tildeio/helix/issues/143).
+
+Can be removed when: That issue is fixed, or an alternative
+workaround is suggested.
+
+### Threads as a Control Flow Mechanism
+
+Rather than attempt to encode the generation state machine
+explicitly, which was proving to be absolutely awful, I
+decided to continue to write it synchronously. The Rust side
+of the equation does not control calling the test function,
+which makes this tricky (and having the asynchronous interface
+as the main API entry point is a long term good anyway).
+
+The ideal way of doing this would be with something lightweight,
+like a coroutines. The ideal way of doing coroutines would be
+[Rust generators](https://doc.rust-lang.org/nightly/unstable-book/language-features/generators.html).
+
+Unfortunately this suffers from two problems:
+
+* It requires rust nightly. I would be prepared to live with this,
+  but it's sub-par.
+* The current implementation is one-way only: resume does not take
+  an argument.
+
+Alternate things tried: 
+
+* [libfringe](https://github.com/edef1c/libfringe) seems lovely,
+  but also requires rust-nightly and the released version doesn't
+  actually build on rust nightly
+* I didn't really look into [may](https://github.com/Xudong-Huang/may/)
+  after a) getting vaguely warned off it and b) Honestly having
+  coroutine implementation exhaustion at this point.
+
+So at this point I said "Screw it, threads work on stable, and the
+context switching overhead isn't going to be *that* large compared
+to all the other mess that's in this chain, so..."
+
+So, yeah, that's why the main loop runs in a separate thread and
+communicates with the main thread via a synchronous channel.
+
+Can be removed when one of:
+
+* Generators are on stable and support resuming with an argument.
+* libfringe works on stable
+* Either of the above but on unstable, and my frustration with
+  threading bugs (but fearless concurrency, David!) outweighs
+  my desire to not use nightly.

--- a/AWFUL-HACKS.md
+++ b/AWFUL-HACKS.md
@@ -83,3 +83,13 @@ Can be removed when one of:
 * Either of the above but on unstable, and my frustration with
   threading bugs (but fearless concurrency, David!) outweighs
   my desire to not use nightly.
+
+
+### Monkey-patching Helix for our Build
+
+I was very very bored of Helix's build support [not actually failing
+the rake task when the build fails](https://github.com/tildeio/helix/issues/133),
+so I've monkey-patched their build system in our Rakefile in order
+to make it error properly in this case.
+
+Can be removed when: The linked issue is fixed.

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,18 @@ RSpec::Core::RakeTask.new(:test)
 
 RuboCop::RakeTask.new
 
+# Monkeypatch build to fail on error.
+# See https://github.com/tildeio/helix/issues/133
+module HelixRuntime
+  class Project
+    alias original_build cargo_build
+
+    def cargo_build
+      raise 'Build failed' unless original_build
+    end
+  end
+end
+
 HelixRuntime::BuildTask.new
 
 task test: :build

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -4,6 +4,7 @@ require 'hypothesis/errors'
 require 'hypothesis/providers'
 require 'hypothesis/engine'
 require 'hypothesis/world'
+require 'hypothesis/debug'
 
 module Hypothesis
   def hypothesis(options = {}, &block)

--- a/lib/hypothesis/debug.rb
+++ b/lib/hypothesis/debug.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hypothesis
+  module Debug
+    def find(options = {}, &block)
+      unless Hypothesis::World.current_engine.nil?
+        raise UsageError, 'Cannot nest hypothesis calls'
+      end
+      begin
+        Hypothesis::World.current_engine = Hypothesis::Engine.new(**options)
+        Hypothesis::World.current_engine.is_find = true
+        Hypothesis::World.current_engine.run(&block)
+        Hypothesis::World.current_engine.current_source.draws
+      ensure
+        Hypothesis::World.current_engine = nil
+      end
+    end
+  end
+end

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -6,6 +6,7 @@ require 'hypothesis-ruby-core/native'
 module Hypothesis
   class Engine
     attr_reader :current_source
+    attr_accessor :is_find
 
     def initialize(max_examples: 200, seed: nil)
       seed = Random.rand(2**64 - 1) if seed.nil?
@@ -15,14 +16,17 @@ module Hypothesis
     def run
       while @core_engine.should_continue
         core_id = @core_engine.new_source
+        break if core_id.nil?
         @current_source = Source.new(@core_engine, core_id)
         begin
-          yield(@current_source)
+          result = yield(@current_source)
+          @core_engine.finish_interesting(core_id) if is_find && result
         rescue UnsatisfiedAssumption
           @core_engine.finish_invalid(core_id)
         rescue DataOverflow
           @core_engine.finish_overflow(core_id)
         rescue StandardError
+          raise if is_find
           @core_engine.finish_interesting(core_id)
         else
           @core_engine.finish_valid(core_id)
@@ -32,15 +36,19 @@ module Hypothesis
       core_id = @core_engine.failing_example
       return if core_id.nil?
 
-      @current_source = Source.new(@core_engine, core_id)
+      @current_source = Source.new(@core_engine, core_id, record_draws: is_find)
       yield @current_source
     end
   end
 
   class Source
-    def initialize(core_engine, core_id)
+    attr_reader :draws
+
+    def initialize(core_engine, core_id, record_draws: false)
       @core_engine = core_engine
       @core_id = core_id
+
+      @draws = [] if record_draws
     end
 
     def bits(n)
@@ -51,7 +59,9 @@ module Hypothesis
 
     def given(provider = nil, &block)
       provider ||= block
-      provider.call(self)
+      result = provider.call(self)
+      draws&.push(result)
+      result
     end
 
     def assume(condition)

--- a/spec/basic_examples_spec.rb
+++ b/spec/basic_examples_spec.rb
@@ -4,8 +4,8 @@ def expect_failure(&block)
   expect(&block).to raise_exception(RSpec::Expectations::ExpectationNotMetError)
 end
 
-RSpec.describe 'some basic hypothesis tests' do
-  it 'should think integer addition is commutative' do
+RSpec.describe 'basic hypothesis tests' do
+  it 'think integer addition is commutative' do
     hypothesis do
       x = given integers
       y = given integers
@@ -13,7 +13,7 @@ RSpec.describe 'some basic hypothesis tests' do
     end
   end
 
-  it 'should be able to find zero values' do
+  it 'are able to find zero values' do
     expect_failure do
       hypothesis do
         x = given integers
@@ -22,7 +22,7 @@ RSpec.describe 'some basic hypothesis tests' do
     end
   end
 
-  it 'should be able to filter out values' do
+  it 'are able to filter out values' do
     hypothesis do
       x = given integers
       assume x != 0
@@ -30,7 +30,7 @@ RSpec.describe 'some basic hypothesis tests' do
     end
   end
 
-  it 'should find that string addition is not commutative' do
+  it 'find that string addition is not commutative' do
     expect_failure do
       hypothesis do
         x = given strings

--- a/spec/example_shrinking_spec.rb
+++ b/spec/example_shrinking_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe 'shrinking' do
+  include Hypothesis::Debug
+
+  it 'finds lower bounds on integers' do
+    n, = find { given(integers) >= 10 }
+    expect(n).to eq(10)
+  end
+end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,36 +7,23 @@ extern crate rand;
 
 use rand::{ChaChaRng, Rng, SeedableRng};
 use std::collections::HashMap;
-use std::rc::Rc;
+
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::thread;
+use std::mem;
+
+type DataStream = Vec<u64>;
 
 #[derive(Debug, Clone)]
 enum BitGenerator {
     Random(ChaChaRng),
-    Recorded(Rc<Vec<u64>>),
+    Recorded(DataStream),
 }
 
 #[derive(Debug, Clone)]
 struct DataSource {
     bitgenerator: BitGenerator,
-    record: Vec<u64>,
-}
-
-#[derive(Debug, Clone)]
-enum Status {
-    Overflow,
-    Invalid,
-    Valid,
-    Interesting,
-}
-
-#[derive(Debug, Clone)]
-struct Engine {
-    random: ChaChaRng,
-    max_examples: u64,
-    valid_examples: u64,
-    invalid_examples: u64,
-    interesting_examples: u64,
-    best_example: Option<Rc<Vec<u64>>>,
+    record: DataStream,
 }
 
 impl DataSource {
@@ -63,7 +50,7 @@ impl DataSource {
     fn new(generator: BitGenerator) -> DataSource {
         return DataSource {
             bitgenerator: generator,
-            record: Vec::new(),
+            record: DataStream::new(),
         };
     }
 
@@ -71,49 +58,284 @@ impl DataSource {
         return DataSource::new(BitGenerator::Random(random));
     }
 
-    fn from_vec(record: Rc<Vec<u64>>) -> DataSource {
+    fn from_vec(record: DataStream) -> DataSource {
         return DataSource::new(BitGenerator::Recorded(record));
+    }
+
+    fn to_result(self, status: Status) -> TestResult {
+        TestResult {
+            record: self.record,
+            status: status,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Status {
+    Overflow,
+    Invalid,
+    Valid,
+    Interesting,
+}
+
+#[derive(Debug, Clone)]
+struct TestResult {
+    record: DataStream,
+    status: Status,
+}
+
+impl TestResult {
+    fn dummy() -> TestResult {
+        TestResult {
+            record: Vec::new(),
+            status: Status::Invalid,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum LoopExitReason {
+    Complete,
+    //MaxExamples,
+    //MaxShrinks,
+    Shutdown,
+    //Error(String),
+}
+
+#[derive(Debug)]
+enum LoopCommand {
+    RunThis(DataSource),
+    Finished(LoopExitReason, MainGenerationLoop),
+    UnexpectedTermination,
+}
+
+#[derive(Debug)]
+struct MainGenerationLoop {
+    receiver: Receiver<TestResult>,
+    sender: SyncSender<LoopCommand>,
+    max_examples: u64,
+    random: ChaChaRng,
+
+    shrink_target: TestResult,
+
+    valid_examples: u64,
+    invalid_examples: u64,
+    interesting_examples: u64,
+}
+
+type StepResult = Result<(), LoopExitReason>;
+
+impl MainGenerationLoop {
+    fn run(mut self) {
+        let result = self.loop_body();
+        match result {
+            // Silent shutdown when the main thread terminates
+            Err(LoopExitReason::Shutdown) => (),
+            Err(reason) => {
+                // Must clone because otherwise it is borrowed.
+                let shutdown_sender = self.sender.clone();
+                shutdown_sender
+                    .send(LoopCommand::Finished(reason, self))
+                    .unwrap()
+            }
+            Ok(_) => panic!("BUG: Generation loop was not supposed to return normally."),
+        }
+    }
+
+    fn loop_body(&mut self) -> StepResult {
+        self.generate_examples()?;
+        self.shrink_examples()?;
+        return Err(LoopExitReason::Complete);
+    }
+
+    fn generate_examples(&mut self) -> StepResult {
+        while self.valid_examples < self.max_examples
+            && self.shrink_target.status != Status::Interesting
+        {
+            let r = self.random.gen();
+            self.execute(DataSource::from_random(r))?;
+        }
+        return Ok(());
+    }
+
+    fn shrink_examples(&mut self) -> StepResult {
+        assert!(self.shrink_target.status == Status::Interesting);
+        let mut i = 0;
+
+        let mut attempt = self.shrink_target.record.clone();
+
+        while i < self.shrink_target.record.len() {
+            assert!(attempt.len() >= self.shrink_target.record.len());
+            attempt.truncate(self.shrink_target.record.len());
+
+            let mut hi = self.shrink_target.record[i];
+
+            if hi > 0 {
+                attempt[i] = 0;
+                let zeroed = self.incorporate(&attempt)?;
+                if !zeroed {
+                    let mut lo = 0;
+                    // Binary search to find the smallest value we can
+                    // replace this with.
+                    while lo + 1 < hi {
+                        let mid = lo + (hi - lo) / 2;
+                        attempt[i] = mid;
+                        let succeeded = self.incorporate(&attempt)?;
+                        if succeeded {
+                            hi = mid;
+                        } else {
+                            lo = mid;
+                        }
+                    }
+                    attempt[i] = hi;
+                }
+            }
+
+            i += 1;
+        }
+
+        Ok(())
+    }
+
+    fn incorporate(&mut self, buf: &DataStream) -> Result<bool, LoopExitReason> {
+        let result = self.execute(DataSource::from_vec(buf.clone()))?;
+        return Ok(result.status == Status::Interesting);
+    }
+
+    fn execute(&mut self, source: DataSource) -> Result<TestResult, LoopExitReason> {
+        let result = match self.sender.send(LoopCommand::RunThis(source)) {
+            Ok(_) => match self.receiver.recv() {
+                Ok(t) => t,
+                Err(_) => return Err(LoopExitReason::Shutdown),
+            },
+            Err(_) => return Err(LoopExitReason::Shutdown),
+        };
+        match result.status {
+            Status::Overflow => (),
+            Status::Invalid => self.invalid_examples += 1,
+            Status::Valid => self.valid_examples += 1,
+            Status::Interesting => {
+                self.shrink_target = result.clone();
+                self.interesting_examples += 1;
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug)]
+struct Engine {
+    // Information that we might be asked for.
+    best_example: Option<TestResult>,
+
+    // The next response from the main loop. Once
+    // this is set to Some(Finished(_)) it stays that way,
+    // otherwise it is cleared on access.
+    loop_response: Option<LoopCommand>,
+
+    // Communication channels with the main testing loop
+    receiver: Receiver<LoopCommand>,
+    sender: SyncSender<TestResult>,
+}
+
+impl Clone for Engine {
+    fn clone(&self) -> Engine {
+        panic!("BUG: The Engine was unexpectedly cloned");
     }
 }
 
 impl Engine {
     fn new(max_examples: u64, seed: &[u32]) -> Engine {
-        return Engine {
-            random: ChaChaRng::from_seed(seed),
+        let (send_local, recv_remote) = sync_channel(1);
+        let (send_remote, recv_local) = sync_channel(1);
+
+        let engine = Engine {
+            best_example: None,
+            loop_response: None,
+            sender: send_local,
+            receiver: recv_local,
+        };
+
+        let main_loop = MainGenerationLoop {
             max_examples: max_examples,
+            random: ChaChaRng::from_seed(seed),
+            sender: send_remote,
+            receiver: recv_remote,
+
+            shrink_target: TestResult::dummy(),
             valid_examples: 0,
             invalid_examples: 0,
             interesting_examples: 0,
-            best_example: None,
         };
-    }
 
-    fn should_continue(&self) -> bool {
-        return (self.valid_examples < self.max_examples)
-            && (self.valid_examples + self.invalid_examples < self.max_examples * 10)
-            && (self.interesting_examples == 0);
+        thread::spawn(move || {
+            main_loop.run();
+        });
+
+        return engine;
     }
 
     fn mark_finished(&mut self, source: DataSource, status: Status) -> () {
-        match status {
-            Status::Overflow => (),
-            Status::Valid => self.valid_examples += 1,
-            Status::Invalid => self.invalid_examples += 1,
-            Status::Interesting => {
-                self.interesting_examples += 1;
-                self.best_example = Some(Rc::new(source.record));
+        self.consume_test_result(source.to_result(status))
+    }
+
+    fn next_source(&mut self) -> Option<DataSource> {
+        self.await_loop_response();
+
+        let mut local_result = None;
+        mem::swap(&mut local_result, &mut self.loop_response);
+
+        match local_result {
+            Some(LoopCommand::RunThis(source)) => return Some(source),
+            None => panic!("BUG: Loop response should not be empty at this point"),
+            _ => {
+                self.loop_response = local_result;
+                return None;
             }
         }
     }
 
-    fn new_source(&mut self) -> DataSource {
-        return DataSource::from_random(self.random.gen());
+    fn best_source(&self) -> Option<DataSource> {
+        match &self.best_example {
+            &Some(ref result) => Some(DataSource::from_vec(result.record.clone())),
+            _ => None,
+        }
     }
 
-    fn failing_example(&self) -> Option<DataSource> {
-        match self.best_example {
-            None => return None,
-            Some(ref v) => return Some(DataSource::from_vec(v.clone())),
+    fn consume_test_result(&mut self, result: TestResult) -> () {
+        match result.status {
+            Status::Interesting => self.best_example = Some(result.clone()),
+            _ => (),
+        };
+
+        if self.has_shutdown() {
+            return ();
+        }
+
+        match self.sender.send(result) {
+            Ok(_) => (),
+            Err(_) => self.loop_went_oops(),
+        }
+    }
+
+    fn loop_went_oops(&mut self) {
+        self.loop_response = Some(LoopCommand::UnexpectedTermination)
+    }
+
+    fn has_shutdown(&mut self) -> bool {
+        match &self.loop_response {
+            &Some(LoopCommand::Finished(..)) => true,
+            _ => false,
+        }
+    }
+
+    fn await_loop_response(&mut self) -> () {
+        if self.loop_response.is_none() {
+            match self.receiver.recv() {
+                Ok(response) => self.loop_response = Some(response),
+                Err(_) => self.loop_went_oops(),
+            }
         }
     }
 }
@@ -136,19 +358,20 @@ ruby! {
       }
     }
 
-    def was_unsatisfiable(&self) -> bool {
-      return self.engine.valid_examples == 0 && self.engine.interesting_examples == 0;
-    }
-
-    def new_source(&mut self) -> u64 {
-      let result = self.next_id;
-      self.children.insert(result, self.engine.new_source());
-      self.next_id += 1;
-      return result;
+    def new_source(&mut self) -> Option<u64> {
+      match self.engine.next_source() {
+        None => None,
+        Some(source) => {
+          let result = self.next_id;
+          self.children.insert(result, source);
+          self.next_id += 1;
+          Some(result)
+        }
+      }
     }
 
     def failing_example(&mut self) -> Option<u64> {
-      if let Some(source) = self.engine.failing_example() {
+      if let Some(source) = self.engine.best_source() {
         let result = self.next_id;
         self.children.insert(result, source);
         self.next_id += 1;
@@ -158,8 +381,14 @@ ruby! {
       }
     }
 
-    def should_continue(&self) -> bool {
-      return self.engine.should_continue();
+    def was_unsatisfiable(&mut self) -> bool {
+      match &self.engine.loop_response {
+        &Some(LoopCommand::Finished(_, ref main_loop)) => {
+          main_loop.interesting_examples > 0 || main_loop.valid_examples > 0
+        },
+        _ => false,
+      }
+
     }
 
     def finish_overflow(&mut self, id: u64){


### PR DESCRIPTION
OK this is step one of two towards #8, which is to implement a shrinker for this.

Before you review this, I want to preempt you with some important tasting notes:

1. The phrase "Jesus Christ David" is already in the commit log, and therefore would be redundant in the review process.
2. The document `AWFUL-HACKS.md` that has been added as part of this pull request is probably a good place to start your review.
3. I was entirely sober when the worst crimes of this pull request were committed.
4. I'm sorry.
5. Despite my general air of contrition and despair, I do genuinely think this was the correct decision and that it is both easy to remove in future and will not actually be a major problem if it stays.
6. It's just really gross.

------------------

The problem I was faced with was that the API for crossing the Rust/Ruby boundary has more or less forced us into an asynchronous mode, with Rust very explicitly not in charge of the testing loop. This is good for the long term, but the Hypothesis main loop is naturally really really sequential, especially around shrinking, which causes a bit of a problem in the implementation. 

I started out thinking "Man pattern matching will make implementing a state machine for this so nice".
It doesn't. Implementing a state machine by hand is awful, especially one of the complexity of the Hypothesis shrinker. Pattern matching removes the accidental complexity, but not the intrinsic complexity, and the intrinsic complexity is high.

Long story short, I wanted generators, but no can has at present, which is why the main loop is now, err, in a separate thread.

Look, honestly, this was the right way to do it, I promise. The threadiness is contained and can be removed at a later date when coroutine based options work better, and the alternatives were some an order of magnitude more work and/or not currently viable. Read `AWFUL-HACKS.md` if you don't believe me.

Anyway!

The control flow is now this:

1. All of the actual decisions to be made happen inside `MainGenerationLoop.run()`.
2. This runs in a separate thread, but it communicates back to the origin thread in an extremely synchronous manner.
3. All test executions happen in the main thread, so the background thread should never be visible to an end user.

This lets us write the main loop entirely synchronously as desired, which will enable an honestly quite clean direct port of the main Hypothesis shrinker with comparatively little work.

I mean, clean other than the interface layer.

Anyway, the part of the shrinker that this pull request implements is very basic: It just does a binary search on each block of bits drawn by the test, with no attempt to reduce data size. It's mostly just a straw place holder that forced me to figure out how this was supposed to work.