### PR TITLE
Support example printing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,5 @@ Metrics/AbcSize:
   Enabled: false
 Lint/RescueException:
   Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false

--- a/AWFUL-HACKS.md
+++ b/AWFUL-HACKS.md
@@ -84,7 +84,6 @@ Can be removed when one of:
   threading bugs (but fearless concurrency, David!) outweighs
   my desire to not use nightly.
 
-
 ### Monkey-patching Helix for our Build
 
 I was very very bored of Helix's build support [not actually failing
@@ -93,3 +92,30 @@ so I've monkey-patched their build system in our Rakefile in order
 to make it error properly in this case.
 
 Can be removed when: The linked issue is fixed.
+
+### Using Eigenclasses for Example Printing
+
+Right. So. I asked Sam (and he should know) how to print stuff in
+rspec. The only viable answer appears to be "Use exceptions and
+define their to\_s method".
+
+But I want to support arbitrary user exceptions. It would suck
+to make people to use an entirely different set of matchers within
+Hypothesis than outside of Hypothesis, and it would be annoying
+to change the exception type just because you were using Hypothesis:
+The general goal here is that Hypothesis should more or less
+be invisible in your test output except to the extent that it needs
+to tell you what it did.
+
+So, how to reconcile these two things?
+
+Well... The to\_s on the exception class will be called, but there's
+nothing to say it has to be the same implementation of it that you
+started with, right? And we've got the exception object sitting
+right there, with it's friendly little eigenclass that we can
+attach things to, right?
+
+Anyway, that's how we print examples now. Sorry.
+
+Can be removed when: Dear Rspec developers. I owe you a proposed
+"details" API suggestion.

--- a/AWFUL-HACKS.md
+++ b/AWFUL-HACKS.md
@@ -97,7 +97,8 @@ Can be removed when: The linked issue is fixed.
 
 Right. So. I asked Sam (and he should know) how to print stuff in
 rspec. The only viable answer appears to be "Use exceptions and
-define their to\_s method".
+define their `to_s` method" (Though FUN FACT, minitest and RSpec
+disagree on whether to use `inspect` or `to_s`.
 
 But I want to support arbitrary user exceptions. It would suck
 to make people to use an entirely different set of matchers within
@@ -117,5 +118,10 @@ attach things to, right?
 
 Anyway, that's how we print examples now. Sorry.
 
-Can be removed when: Dear Rspec developers. I owe you a proposed
-"details" API suggestion.
+Can be removed when: We might be stuck with this one unless we can
+get a "details" API upstream to both RSPec and minitest, and any
+other thing it might be reasonable to support.
+
+This is highly aesthetically displeasing but actually not too bad
+in effect. The damage is pretty localised, and the results seem
+to be good.

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -19,11 +19,11 @@ module Hypothesis
     end
   end
 
-  def given(provider = nil, &block)
+  def given(*args, &block)
     if World.current_engine.nil?
       raise UsageError, 'Cannot call given outside of a hypothesis block'
     end
-    World.current_engine.current_source.given(provider, &block)
+    World.current_engine.current_source.given(*args, &block)
   end
 
   def assume(condition)

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -55,21 +55,25 @@ module Hypothesis
             "Given #{name}: #{s}"
           end.to_a
 
-          original_to_s = e.to_s
-          original_inspect = e.inspect
+          if e.respond_to? :hypothesis_data
+            e.hypothesis_data[0] = given_str
+          else
+            original_to_s = e.to_s
+            original_inspect = e.inspect
 
-          class <<e
-            attr_accessor :hypothesis_data
+            class <<e
+              attr_accessor :hypothesis_data
 
-            def to_s
-              ['', hypothesis_data[0], '', hypothesis_data[1]].join("\n")
+              def to_s
+                ['', hypothesis_data[0], '', hypothesis_data[1]].join("\n")
+              end
+
+              def inspect
+                ['', hypothesis_data[0], '', hypothesis_data[2]].join("\n")
+              end
             end
-
-            def inspect
-              ['', hypothesis_data[0], '', hypothesis_data[2]].join("\n")
-            end
+            e.hypothesis_data = [given_str, original_to_s, original_inspect]
           end
-          e.hypothesis_data = [given_str, original_to_s, original_inspect]
           raise e
         end
       end

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -49,20 +49,27 @@ module Hypothesis
         begin
           yield @current_source
         rescue Exception => e
-          str_value = e.to_s
+          givens = @current_source.print_log
+          given_str = givens.each_with_index.map do |(name, s), i|
+            name = "##{i + 1}" if name.nil?
+            "Given #{name}: #{s}"
+          end.to_a
+
+          original_to_s = e.to_s
+          original_inspect = e.inspect
 
           class <<e
             attr_accessor :hypothesis_data
 
             def to_s
-              source, str_value = hypothesis_data
-              (source.print_log.each_with_index.map do |(name, s), i|
-                name = "##{i + 1}" if name.nil?
-                "Given #{name}: #{s}"
-              end.to_a + ['', str_value]).join("\n")
+              ['', hypothesis_data[0], '', hypothesis_data[1]].join("\n")
+            end
+
+            def inspect
+              ['', hypothesis_data[0], '', hypothesis_data[2]].join("\n")
             end
           end
-          e.hypothesis_data = [@current_source, str_value]
+          e.hypothesis_data = [given_str, original_to_s, original_inspect]
           raise e
         end
       end

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'printing examples' do
+  it 'adds a statement to the exceptions string' do
+    expect do
+      hypothesis do
+        n = given integers
+        expect(n).to eq(0)
+      end
+    end.to raise_exception(/Given #1/)
+  end
+
+  it 'adds multiple statements to the exceptions string' do
+    expect do
+      hypothesis do
+        n = given integers
+        m = given integers
+        expect(n).to eq(m)
+      end
+    end.to raise_exception(/Given #1.+Given #2/m)
+  end
+
+  it 'includes the name in the Given' do
+    expect do
+      hypothesis do
+        n = given integers, name: 'fred'
+        expect(n).to eq(1)
+      end
+    end.to raise_exception(/Given fred:/)
+  end
+end

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe 'printing examples' do
       end
     end.to raise_exception(/Given fred:/)
   end
+
+  it 'does not mangle names if you reuse exceptions' do
+    shared = Exception.new('Stuff')
+    3.times do
+      expect do
+        hypothesis do
+          given integers
+          raise shared
+        end
+      end.to raise_exception do |ex|
+        expect(ex).to equal(shared)
+        expect(ex.to_s.scan(/Given/).count).to eq(1)
+        expect(ex.to_s.scan(/Stuff/).count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
A um, slightly idiosyncratic but surprisingly effective approach to printing examples in tests.

Core idea: If tests are going to print the errors and nothing but the errors, lets control what tests are printing by controlling how the errors print. Thanks to Ruby's... lets go with "flexible design choices" this is surprisingly easy to do for arbitrary exceptions!

I'm on the fence as to how much I hate this solution. When I came up with it I hated it a lot (but also was giggling constantly), but the more I think about it the more I kinda like it. It works pretty universally and looks good in both rspec and minitest.

A details API probably *would* be better, but I think this solution is likely here to stay long-term. I certainly prefer it to using monkey-patching to implement our own such API.

(Fixes #6)