### PR TITLE
Start to sketch out how we can properly implement providers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,5 @@ Style/MultilineBlockChain:
   Enabled: false
 Style/MethodMissing:
   Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,5 @@ Style/MixinUsage:
   Enabled: false
 Style/MultilineBlockChain:
   Enabled: false
+Style/MethodMissing:
+  Enabled: false

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -90,12 +90,6 @@ module Hypothesis
       @print_log = [] if print_draws
     end
 
-    def given(provider)
-      result = local_given(provider)
-      draws&.push(result)
-      result
-    end
-
     def given(provider = nil, name: nil, &block)
       provider ||= block
       result = provider.provide(self)

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -88,18 +88,24 @@ module Hypothesis
 
       @draws = [] if record_draws
       @print_log = [] if print_draws
+      @depth = 0
     end
 
     def given(provider = nil, name: nil, &block)
-      provider ||= block
-      result = provider.provide(self)
-      draws&.push(result)
-      print_log&.push([name, result.inspect])
-      result
-    end
+      top_level = @depth == 0
 
-    def local_given(provider)
-      provider.provide(self)
+      begin
+        @depth += 1
+        provider ||= block
+        result = provider.provide(self)
+        if top_level
+          draws&.push(result)
+          print_log&.push([name, result.inspect])
+        end
+        result
+      ensure
+        @depth -= 1
+      end
     end
 
     def assume(condition)

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -92,7 +92,7 @@ module Hypothesis
     end
 
     def given(provider = nil, name: nil, &block)
-      top_level = @depth == 0
+      top_level = @depth.zero?
 
       begin
         @depth += 1

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -7,13 +7,13 @@ module Hypothesis
     end
 
     def composite(&block)
-      Hypothesis::Provider::Implementations::CompositeProvider.new(self, block)
+      Hypothesis::Provider::Implementations::CompositeProvider.new(block)
     end
 
     def integers
-      composite do
-        if given(bits(1)).positive?
-          given(bits(64))
+      composite do |source|
+        if source.given(bits(1)).positive?
+          source.given(bits(64))
         else
           0
         end
@@ -21,8 +21,8 @@ module Hypothesis
     end
 
     def strings
-      composite do
-        if given(bits(1)).positive?
+      composite do |source|
+        if source.given(bits(1)).positive?
           'a'
         else
           'b'
@@ -41,37 +41,13 @@ module Hypothesis
 
   class Provider
     module Implementations
-      class CompositeObject
-        def initialize(parent, source)
-          @parent = parent
-          @source = source
-        end
-
-        def given(provider)
-          @source.given(provider)
-        end
-
-        def assume(condition)
-          @source.assume(condition)
-        end
-
-        def respond_to_missing?(name)
-          @parent.respond_to? name
-        end
-
-        def method_missing(name, *args, &block)
-          @parent.send(name, *args, &block)
-        end
-      end
-
       class CompositeProvider < Provider
-        def initialize(parent, block)
-          @parent = parent
+        def initialize(block)
           @block = block
         end
 
         def provide(source)
-          CompositeObject.new(@parent, source).instance_eval(&@block)
+          @block.call(source)
         end
       end
 

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -48,7 +48,7 @@ module Hypothesis
         end
 
         def given(provider)
-          @source.local_given(provider)
+          @source.given(provider)
         end
 
         def assume(condition)

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -2,10 +2,18 @@
 
 module Hypothesis
   module Providers
+    def bits(n)
+      from_hypothesis_core HypothesisCoreBitProvider.new(n)
+    end
+
+    def composite(&block)
+      Hypothesis::Provider::Implementations::CompositeProvider.new(self, block)
+    end
+
     def integers
-      proc do |source|
-        if source.bits(1).positive?
-          source.bits(64)
+      composite do
+        if given(bits(1)).positive?
+          given(bits(64))
         else
           0
         end
@@ -13,11 +21,69 @@ module Hypothesis
     end
 
     def strings
-      proc do |source|
-        if source.bits(1).positive?
+      composite do
+        if given(bits(1)).positive?
           'a'
         else
           'b'
+        end
+      end
+    end
+
+    private
+
+    def from_hypothesis_core(core)
+      Hypothesis::Provider::Implementations::ProviderFromCore.new(
+        core
+      )
+    end
+  end
+
+  class Provider
+    module Implementations
+      class CompositeObject
+        def initialize(parent, source)
+          @parent = parent
+          @source = source
+        end
+
+        def given(provider)
+          @source.local_given(provider)
+        end
+
+        def assume(condition)
+          @source.assume(condition)
+        end
+
+        def respond_to_missing?(name)
+          @parent.respond_to? name
+        end
+
+        def method_missing(name, *args, &block)
+          @parent.send(name, *args, &block)
+        end
+      end
+
+      class CompositeProvider < Provider
+        def initialize(parent, block)
+          @parent = parent
+          @block = block
+        end
+
+        def provide(source)
+          CompositeObject.new(@parent, source).instance_eval(&@block)
+        end
+      end
+
+      class ProviderFromCore < Provider
+        def initialize(core_provider)
+          @core_provider = core_provider
+        end
+
+        def provide(data)
+          result = @core_provider.provide(data.wrapped_data)
+          raise Hypothesis::DataOverflow if result.nil?
+          result
         end
       end
     end

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -46,17 +46,16 @@ RSpec.describe 'printing examples' do
   end
 
   it 'does not include nested givens in printing' do
-
     expect do
       hypothesis do
-        value = given(composite do
-          given integers
-          given integers
-          given integers
+        value = given(composite do |source|
+          source.given integers
+          source.given integers
+          source.given integers
         end)
         expect(value).to eq(0)
       end
-    end.to raise_exception do |ex|
+    end.to raise_exception(RSpec::Expectations::ExpectationNotMetError) do |ex|
       expect(ex.to_s.scan(/Given/).count).to eq(1)
     end
   end

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -44,4 +44,20 @@ RSpec.describe 'printing examples' do
       end
     end
   end
+
+  it 'does not include nested givens in printing' do
+
+    expect do
+      hypothesis do
+        value = given(composite do
+          given integers
+          given integers
+          given integers
+        end)
+        expect(value).to eq(0)
+      end
+    end.to raise_exception do |ex|
+      expect(ex.to_s.scan(/Given/).count).to eq(1)
+    end
+  end
 end

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,8 @@ use rand::{ChaChaRng, Rng};
 
 pub type DataStream = Vec<u64>;
 
+pub struct FailedDraw;
+
 #[derive(Debug, Clone)]
 enum BitGenerator {
     Random(ChaChaRng),
@@ -22,11 +24,11 @@ pub struct DataSource {
 }
 
 impl DataSource {
-    pub fn bits(&mut self, n_bits: u64) -> Option<u64> {
+    pub fn bits(&mut self, n_bits: u64) -> Result<u64, FailedDraw> {
         let mut result = match self.bitgenerator {
             BitGenerator::Random(ref mut random) => random.next_u64(),
             BitGenerator::Recorded(ref mut v) => if self.record.len() >= v.len() {
-                return None;
+                return Err(FailedDraw);
             } else {
                 v[self.record.len()]
             },
@@ -39,7 +41,7 @@ impl DataSource {
 
         self.record.push(result);
 
-        return Some(result);
+        return Ok(result);
     }
 
     fn new(generator: BitGenerator) -> DataSource {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ ruby! {
 
     def bits(&mut self, id: u64, n_bits: u64) -> Option<u64> {
       match self.children.get_mut(&id) {
-        None => return None,
-        Some(source) => return source.bits(n_bits)
+        Some(source) => source.bits(n_bits).ok(),
+        _ => return None,
       }
     }
   }


### PR DESCRIPTION
This provides the first "real looking" provider implementations, although the actual ones we're using (integers and strings) are still entirely toy.

The basic idea is that we want all primitive providers in Rust, and then to wrap them from Ruby. Ruby will then handle high level composite things for generating its own data types, but low level stuff like control flow, floats, bits, integers, etc. will happen in Rust. Right now all I've done is create a `bits` provider where it was previously a method on `Source` and rebuild the current toy providers on top of that.

Figuring this out required me to sort out some Rust/Ruby interaction that was previously weird AF. It turns out that I had misunderstood a restriction that Helix was imposing on us, and that the actual one imposed is much much more reasonable: Arguments to Helix defined methods cannot be `&mut` *except when they are another Helix object*. This obviates the need for some of the really weird stuff we were doing with basically faking pointers across the language boundary. 🎉 🎉 🎉

PS. Ruby people: Some feedback on the `composite` stuff would be nice. I think it's going to be very pleasant to use, but doing Weird Shit with `method_missing` is probably something I should be avoiding, so if you can think of a nicer way to achieve the same results that would be grand.