### PR TITLE
Track engine state for ease of debugging

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -238,8 +238,9 @@ impl Engine {
 
     pub fn next_source(&mut self) -> Option<DataSource> {
         assert!(self.state == EngineState::ReadyToProvide);
-        self.await_loop_response();
         self.state = EngineState::AwaitingCompletion;
+
+        self.await_loop_response();
 
         let mut local_result = None;
         mem::swap(&mut local_result, &mut self.loop_response);
@@ -264,6 +265,7 @@ impl Engine {
     fn consume_test_result(&mut self, result: TestResult) -> () {
         assert!(self.state == EngineState::AwaitingCompletion);
         self.state = EngineState::ReadyToProvide;
+
         match result.status {
             Status::Interesting => self.best_example = Some(result.clone()),
             _ => (),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -171,6 +171,12 @@ impl MainGenerationLoop {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum EngineState {
+    AwaitingCompletion,
+    ReadyToProvide,
+}
+
 #[derive(Debug)]
 pub struct Engine {
     // Information that we might be asked for.
@@ -180,6 +186,8 @@ pub struct Engine {
     // this is set to Some(Finished(_)) it stays that way,
     // otherwise it is cleared on access.
     loop_response: Option<LoopCommand>,
+
+    state: EngineState,
 
     // Communication channels with the main testing loop
     receiver: Receiver<LoopCommand>,
@@ -202,6 +210,7 @@ impl Engine {
             loop_response: None,
             sender: send_local,
             receiver: recv_local,
+            state: EngineState::ReadyToProvide,
         };
 
         let main_loop = MainGenerationLoop {
@@ -228,7 +237,9 @@ impl Engine {
     }
 
     pub fn next_source(&mut self) -> Option<DataSource> {
+        assert!(self.state == EngineState::ReadyToProvide);
         self.await_loop_response();
+        self.state = EngineState::AwaitingCompletion;
 
         let mut local_result = None;
         mem::swap(&mut local_result, &mut self.loop_response);
@@ -251,6 +262,8 @@ impl Engine {
     }
 
     fn consume_test_result(&mut self, result: TestResult) -> () {
+        assert!(self.state == EngineState::AwaitingCompletion);
+        self.state = EngineState::ReadyToProvide;
         match result.status {
             Status::Interesting => self.best_example = Some(result.clone()),
             _ => (),


### PR DESCRIPTION
I just lost half an hour to a bug which turned out to be because of a merge conflict, but the real problem with it was that there was effectively a deadlock (boy it's nice having our core loop be concurrent, isn't it???) when the wrong thing happened: If you asked the engine for a new example before you told it what happened to the old one, it would hang indefinitely.

This was Great Fun To Debug.

Anyway, this fixes that by just making the engine track what state it's in and error if you call it while it's in the wrong state. This won't work if assertions are turned off, but that's OK: This really is just a debugging feature, and if this ever fires it's because of a bug in the program, so we're not relying on this for correctness.

(Side note: Apparently Helix translates assertion failures Rust side into AssertionErrors ruby side, which is remarkably nice of it!)