### PR TITLE
Add less basic implementation of integers

### DIFF
--- a/lib/hypothesis/debug.rb
+++ b/lib/hypothesis/debug.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require 'hypothesis/errors'
+
 module Hypothesis
   module Debug
+    class NoSuchExample < HypothesisError
+    end
+
     def find(options = {}, &block)
       unless Hypothesis::World.current_engine.nil?
         raise UsageError, 'Cannot nest hypothesis calls'
@@ -10,7 +15,9 @@ module Hypothesis
         Hypothesis::World.current_engine = Hypothesis::Engine.new(**options)
         Hypothesis::World.current_engine.is_find = true
         Hypothesis::World.current_engine.run(&block)
-        Hypothesis::World.current_engine.current_source.draws
+        source = Hypothesis::World.current_engine.current_source
+        raise NoSuchExample if source.nil?
+        source.draws
       ensure
         Hypothesis::World.current_engine = nil
       end

--- a/lib/hypothesis/engine.rb
+++ b/lib/hypothesis/engine.rb
@@ -34,6 +34,7 @@ module Hypothesis
           @core_engine.finish_interesting(core)
         end
       end
+      @current_source = nil
       core = @core_engine.failing_example
       if core.nil?
         raise Unsatisfiable if @core_engine.was_unsatisfiable

--- a/lib/hypothesis/errors.rb
+++ b/lib/hypothesis/errors.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 module Hypothesis
-  class Error < RuntimeError
+  class HypothesisError < RuntimeError
   end
 
-  class Unsatisfiable < Error
+  class Unsatisfiable < HypothesisError
   end
 
-  class UnsatisfiedAssumption < Error
+  class UnsatisfiedAssumption < HypothesisError
   end
 
-  class DataOverflow < Error
+  class DataOverflow < HypothesisError
   end
 
-  class UsageError < Error
+  class UsageError < HypothesisError
   end
 end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -31,8 +31,24 @@ module Hypothesis
       end
     end
 
-    def integers
-      from_hypothesis_core HypothesisCoreIntegers.new
+    def integers(min: nil, max: nil)
+      base = from_hypothesis_core HypothesisCoreIntegers.new
+      if min.nil? && max.nil?
+        base
+      elsif min.nil?
+        composite { |source| max - source.given(base).abs }
+      elsif max.nil?
+        composite { |source| min + source.given(base).abs }
+      else
+        bounded = from_hypothesis_core(
+          HypothesisCoreBoundedIntegers.new(max - min)
+        )
+        if min.zero?
+          bounded
+        else
+          composite { |_source| min + given(bounded) }
+        end
+      end
     end
 
     def strings

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -32,13 +32,7 @@ module Hypothesis
     end
 
     def integers
-      composite do |source|
-        if source.given(bits(1)).positive?
-          source.given(bits(64))
-        else
-          0
-        end
-      end
+      from_hypothesis_core HypothesisCoreIntegers.new
     end
 
     def strings

--- a/spec/example_discovery_spec.rb
+++ b/spec/example_discovery_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hypothesis' do
+  include Hypothesis::Debug
+
+  it 'can find mid sized integers' do
+    n, = find do
+      m = given(integers)
+      m >= 100 && m <= 1000
+    end
+    expect(n).to eq(100)
+  end
+end

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'integer providers' do
+  they 'respect upper bounds' do
+    hypothesis do
+      expect(given(integers(max: 100))).to be <= 100
+    end
+  end
+
+  they 'respect lower bounds' do
+    hypothesis do
+      expect(given(integers(min: -100))).to be >= -100
+    end
+  end
+
+  they 'respect both bounds at once when lower bound is zero' do
+    hypothesis do
+      n = given integers(min: 0, max: 100)
+      expect(n).to be <= 100
+      expect(n).to be >= 0
+    end
+  end
+
+  they 'respect both bounds at once when lower bound is non-zero' do
+    hypothesis do
+      n = given integers(min: 1, max: 100)
+      expect(n).to be <= 100
+      expect(n).to be >= 1
+    end
+  end
+end

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -1,11 +1,30 @@
 use data::{DataSource, FailedDraw};
 
+use std::collections::BinaryHeap;
+use std::mem;
+use std::cmp::{Ord, Ordering, PartialOrd, Reverse};
+
+type Draw<T> = Result<T, FailedDraw>;
+
 pub fn weighted(source: &mut DataSource, probability: f64) -> Result<bool, FailedDraw> {
     // TODO: Less bit-hungry implementation.
 
     let truthy = (probability * (u64::max_value() as f64 + 1.0)).floor() as u64;
     let probe = source.bits(64)?;
     return Ok(probe >= u64::max_value() - truthy + 1);
+}
+
+pub fn bounded_int(source: &mut DataSource, max: u64) -> Draw<u64> {
+    let bitlength = 64 - max.leading_zeros() as u64;
+    if bitlength == 0 {
+        return Ok(0);
+    }
+    loop {
+        let probe = source.bits(bitlength)?;
+        if probe <= max {
+            return Ok(probe);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -55,5 +74,160 @@ impl Repeat {
             _ => (),
         }
         return result;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SamplerEntry {
+    primary: usize,
+    alternate: usize,
+    use_alternate: f32,
+}
+
+impl SamplerEntry {
+    fn single(i: usize) -> SamplerEntry {
+        SamplerEntry {
+            primary: i,
+            alternate: i,
+            use_alternate: 0.0,
+        }
+    }
+}
+
+impl Ord for SamplerEntry {
+    fn cmp(&self, other: &SamplerEntry) -> Ordering {
+        return self.primary
+            .cmp(&other.primary)
+            .then(self.alternate.cmp(&other.alternate));
+    }
+}
+
+impl PartialOrd for SamplerEntry {
+    fn partial_cmp(&self, other: &SamplerEntry) -> Option<Ordering> {
+        return Some(self.cmp(other));
+    }
+}
+
+impl PartialEq for SamplerEntry {
+    fn eq(&self, other: &SamplerEntry) -> bool {
+        return self.cmp(other) == Ordering::Equal;
+    }
+}
+
+impl Eq for SamplerEntry {}
+
+#[derive(Debug, Clone)]
+pub struct Sampler {
+    table: Vec<SamplerEntry>,
+}
+
+impl Sampler {
+    pub fn new(weights: Vec<f32>) -> Sampler {
+        // FIXME: The correct thing to do here is to allow this,
+        // return early, and make this reject the data, but we don't
+        // currently have the status built into our data properly...
+        assert!(weights.len() > 0);
+
+        let mut table = Vec::new();
+
+        let mut small = BinaryHeap::new();
+        let mut large = BinaryHeap::new();
+
+        let total: f32 = weights.iter().sum();
+
+        let mut scaled_probabilities = Vec::new();
+
+        let n = weights.len() as f32;
+
+        for (i, w) in weights.iter().enumerate() {
+            let scaled = n * w / total;
+            scaled_probabilities.push(scaled);
+            if scaled == 1.0 {
+                table.push(SamplerEntry::single(i))
+            } else if scaled > 1.0 {
+                large.push(Reverse(i));
+            } else {
+                assert!(scaled < 1.0);
+                small.push(Reverse(i));
+            }
+        }
+
+        while !(small.is_empty() || large.is_empty()) {
+            let Reverse(lo) = small.pop().unwrap();
+            let Reverse(hi) = large.pop().unwrap();
+
+            assert!(lo != hi);
+            assert!(scaled_probabilities[hi] > 1.0);
+            assert!(scaled_probabilities[lo] < 1.0);
+            scaled_probabilities[hi] = (scaled_probabilities[hi] + scaled_probabilities[lo]) - 1.0;
+            table.push(SamplerEntry {
+                primary: lo,
+                alternate: hi,
+                use_alternate: 1.0 - scaled_probabilities[lo],
+            });
+
+            if scaled_probabilities[hi] < 1.0 {
+                small.push(Reverse(hi))
+            } else if scaled_probabilities[hi] > 1.0 {
+                large.push(Reverse(hi))
+            } else {
+                table.push(SamplerEntry::single(hi))
+            }
+        }
+        for &Reverse(i) in small.iter() {
+            table.push(SamplerEntry::single(i))
+        }
+        for &Reverse(i) in large.iter() {
+            table.push(SamplerEntry::single(i))
+        }
+
+        for ref mut entry in table.iter_mut() {
+            if entry.alternate < entry.primary {
+                mem::swap(&mut entry.primary, &mut entry.alternate);
+                entry.use_alternate = 1.0 - entry.use_alternate;
+            }
+        }
+
+        table.sort();
+        assert!(table.len() > 0);
+        return Sampler { table: table };
+    }
+
+    pub fn sample(&self, source: &mut DataSource) -> Draw<usize> {
+        assert!(self.table.len() > 0);
+        let i = bounded_int(source, self.table.len() as u64 - 1)? as usize;
+        let entry = &self.table[i];
+        let use_alternate = weighted(source, entry.use_alternate as f64)?;
+        if use_alternate {
+            Ok(entry.alternate)
+        } else {
+            Ok(entry.primary)
+        }
+    }
+}
+
+pub fn good_bitlengths() -> Sampler {
+    let weights = vec!(
+    4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, // 1 byte
+    2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, // 2 bytes
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, // 3 bytes
+    0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, // 4 bytes
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, // 5 bytes
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, // 6 bytes
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, // 7 bytes
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,      // 8 bytes (last bit spare for sign)
+  );
+    assert!(weights.len() == 63);
+    Sampler::new(weights)
+}
+
+pub fn integer_from_bitlengths(source: &mut DataSource, bitlengths: &Sampler) -> Draw<i64> {
+    let bitlength = bitlengths.sample(source)? as u64 + 1;
+    let base = source.bits(bitlength)? as i64;
+    let sign = source.bits(1)?;
+    if sign > 0 {
+        Ok(-base)
+    } else {
+        Ok(base)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,20 @@ ruby! {
       })
     }
   }
+
+  class HypothesisCoreIntegers{
+    struct {
+        bitlengths: distributions::Sampler,
+    }
+    def initialize(helix){
+      return HypothesisCoreIntegers{helix,bitlengths: distributions::good_bitlengths()};
+    }
+    def provide(&mut self, data: &mut HypothesisCoreDataSource) -> Option<i64>{
+      data.source.as_mut().and_then(|ref mut source| {
+        distributions::integer_from_bitlengths(source, &self.bitlengths).ok()
+      })
+    }
+  }
 }
 
 fn mark_child_status(engine: &mut Engine, child: &mut HypothesisCoreDataSource, status: Status) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // crate, and everything else is going to get factored out
 // into its own.
 
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 #![deny(warnings, missing_debug_implementations)]
 
 extern crate core;
@@ -135,6 +135,21 @@ ruby! {
     def provide(&mut self, data: &mut HypothesisCoreDataSource) -> Option<i64>{
       data.source.as_mut().and_then(|ref mut source| {
         distributions::integer_from_bitlengths(source, &self.bitlengths).ok()
+      })
+    }
+  }
+
+  class HypothesisCoreBoundedIntegers{
+    struct {
+        max_value: u64,
+    }
+    def initialize(helix, max_value: u64){
+      return HypothesisCoreBoundedIntegers{helix, max_value: max_value};
+    }
+
+    def provide(&mut self, data: &mut HypothesisCoreDataSource) -> Option<u64>{
+      data.source.as_mut().and_then(|ref mut source| {
+        distributions::bounded_int(source, self.max_value).ok()
       })
     }
   }


### PR DESCRIPTION
This is an attempt to flush out some more Hypothesis generation technology, by way of providing an implementation of `integers` that mostly mirrors hypothesis-python's.

The main work here is getting an implementation of a sampler up and running. This is horrendous overkill for this use case, but is a more broadly useful tool [Here's the Python code this implementation is based off](https://github.com/HypothesisWorks/hypothesis-python/blob/master/src/hypothesis/internal/conjecture/utils.py#L233).