### PR TITLE
Factor out Shrinker and loop shrinks to a fixed point

### DIFF
--- a/spec/example_shrinking_spec.rb
+++ b/spec/example_shrinking_spec.rb
@@ -7,4 +7,17 @@ RSpec.describe 'shrinking' do
     n, = find { given(integers) >= 10 }
     expect(n).to eq(10)
   end
+
+  it 'iterates to a fixed point' do
+    @original = nil
+
+    a, b = find do
+      m = given integers
+      n = given integers
+      m > n && n > 0
+    end
+
+    expect(a).to eq(2)
+    expect(b).to eq(1)
+  end
 end

--- a/src/data.rs
+++ b/src/data.rs
@@ -96,12 +96,3 @@ pub struct TestResult {
     pub record: DataStream,
     pub status: Status,
 }
-
-impl TestResult {
-    pub fn dummy() -> TestResult {
-        TestResult {
-            record: Vec::new(),
-            status: Status::Invalid,
-        }
-    }
-}


### PR DESCRIPTION
This updates the shrink logic in two ways:

* When shrinking has "completed" we now restart from the beginning, and we keep doing that until it hits a fixed point.
* Factors out the shrink logic into a separate Shrinker type that is used to store the shrink state. A nice consequence of this is that we now have better state management in the main loop - there's no longer always a `shrink_target` field that may or may not be in an invalid state.

(Builds on top of #19 because that version of the code is way less broken. Will update base once it's merged)