### PR TITLE
Add mixed and choice_of providers

### DIFF
--- a/lib/hypothesis/debug.rb
+++ b/lib/hypothesis/debug.rb
@@ -22,5 +22,11 @@ module Hypothesis
         Hypothesis::World.current_engine = nil
       end
     end
+
+    def find_any(options = {}, &block)
+      # Currently the same as find, but once we have config
+      # options for shrinking it will turn that off.
+      find(options, &block)
+    end
   end
 end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -31,6 +31,26 @@ module Hypothesis
       end
     end
 
+    def mixed(*args)
+      args = args.flatten
+      indexes = from_hypothesis_core(
+        HypothesisCoreBoundedIntegers.new(args.size - 1)
+      )
+      composite do |source|
+        i = source.given(indexes)
+        source.given(args[i])
+      end
+    end
+
+    def choice_of(values)
+      indexes = from_hypothesis_core(
+        HypothesisCoreBoundedIntegers.new(values.size - 1)
+      )
+      composite do |source|
+        values.fetch(source.given(indexes))
+      end
+    end
+
     def integers(min: nil, max: nil)
       base = from_hypothesis_core HypothesisCoreIntegers.new
       if min.nil? && max.nil?

--- a/spec/choice_spec.rb
+++ b/spec/choice_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe 'choice_of provider' do
+  include Hypothesis::Debug
+
+  it 'includes the first argument' do
+    find_any do
+      m = given choice_of([0, 1])
+      m == 0
+    end
+  end
+
+  it 'includes the last argument' do
+    find_any do
+      m = given choice_of([0, 1, 2, 3])
+      m == 3
+    end
+  end
+end

--- a/spec/debug_spec.rb
+++ b/spec/debug_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe 'find' do
+  include Hypothesis::Debug
+
+  it "raises an error if it can't find anything" do
+    expect do
+      find do
+        given integers
+        false
+      end
+    end.to raise_exception(Hypothesis::Debug::NoSuchExample)
+  end
+end

--- a/spec/mixing_spec.rb
+++ b/spec/mixing_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe 'mixed provider' do
+  include Hypothesis::Debug
+
+  it 'includes the first argument' do
+    find_any do
+      given(mixed(integers, strings)).is_a? Integer
+    end
+  end
+
+  it 'includes the second argument' do
+    find_any do
+      given(mixed(integers, strings)).is_a? String
+    end
+  end
+end


### PR DESCRIPTION
Builds on the work in #20 to add the union providers.

I've chosen quite distinct names for these to avoid the problem where people always always confuse `sampled_from` and `one_of` in hypothesis-python. A certain amount of bike shedding welcome.