### PR TITLE
Add an actual working strings provider

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,5 @@ Style/MethodMissing:
   Enabled: false
 Style/MultilineBlockChain:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -10,20 +10,20 @@ module Hypothesis
       Hypothesis::Provider::Implementations::CompositeProvider.new(block)
     end
 
-    def repeated(min_count: 0, max_count: 10, average_count: 5.0)
+    def repeated(min_count: 0, max_count: 10)
       local_provider_implementation do |source, block|
         rep = HypothesisCoreRepeatValues.new(
-          min_count, max_count, average_count
+          min_count, max_count, (min_count + max_count) * 0.5
         )
         block.call while rep.should_continue(source.wrapped_data)
       end
     end
 
-    def lists(element, min_size: 0, max_size: 10, average_size: 10)
+    def lists(element, min_size: 0, max_size: 10)
       composite do
         result = []
         given repeated(
-          min_count: min_size, max_count: max_size, average_count: average_size
+          min_count: min_size, max_count: max_size
         ) do
           result.push given(element)
         end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -93,10 +93,28 @@ module Hypothesis
   end
 
   class Provider
+    def map
+      Implementations::CompositeProvider.new do |source|
+        yield(source.given(self))
+      end
+    end
+
+    def select
+      Implementations::CompositeProvider.new do |source|
+        result = nil
+        4.times do |i|
+          source.assume(i < 3)
+          result = source.given(self)
+          break if yield(result)
+        end
+        result
+      end
+    end
+
     module Implementations
       class CompositeProvider < Provider
-        def initialize(block)
-          @block = block
+        def initialize(block = nil, &implicit)
+          @block = block || implicit
         end
 
         def provide(source)

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -2,10 +2,6 @@
 
 module Hypothesis
   module Providers
-    def bits(n)
-      from_hypothesis_core HypothesisCoreBitProvider.new(n)
-    end
-
     def composite(&block)
       Hypothesis::Provider::Implementations::CompositeProvider.new(block)
     end

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe 'strings' do
+    they 'respect a non-ascii lower bound' do
+        hypothesis do
+            expect(given(codepoints(min: 127))).to be >= 127
+        end
+    end
+end
+
+
+RSpec.describe 'strings' do
+    include Hypothesis::Debug
+
+    they 'can be ascii' do
+        find_any do
+            s = given(strings(min_size: 3, max_size: 3))
+            s.codepoints.all?{|c| c < 127 }
+        end
+    end
+
+    they 'can be non-ascii' do
+        find_any do
+            given(strings).codepoints.any?{|c| c > 127 }
+        end
+    end
+
+    they 'produce valid strings' do
+        find do
+            s = given(strings)
+            # Shrinking will try and fail to move this into
+            # an invalid codepoint range.
+            s.size > 0 && s.codepoints[0] >= 56785
+        end
+    end
+end

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,7 @@ use rand::{ChaChaRng, Rng};
 
 pub type DataStream = Vec<u64>;
 
+#[derive(Debug, Clone)]
 pub struct FailedDraw;
 
 #[derive(Debug, Clone)]

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -61,6 +61,7 @@ impl Repeat {
     pub fn should_continue(&mut self, source: &mut DataSource) -> Result<bool, FailedDraw> {
         let result = if self.current_count < self.min_count {
             self.draw_until(source, true)?;
+            self.current_count += 1;
             return Ok(true);
         } else if self.current_count >= self.max_count {
             self.draw_until(source, false)?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -181,7 +181,6 @@ where
 
         while i < self.shrink_target.record.len() {
             assert!(attempt.len() >= self.shrink_target.record.len());
-            attempt.truncate(self.shrink_target.record.len());
 
             let mut hi = self.shrink_target.record[i];
 
@@ -197,12 +196,16 @@ where
                         attempt[i] = mid;
                         let succeeded = self.incorporate(&attempt)?;
                         if succeeded {
+                            attempt = self.shrink_target.record.clone();
                             hi = mid;
                         } else {
+                            attempt[i] = self.shrink_target.record[i];
                             lo = mid;
                         }
                     }
                     attempt[i] = hi;
+                } else {
+                    attempt = self.shrink_target.record.clone();
                 }
             }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -216,6 +216,19 @@ where
     }
 
     fn incorporate(&mut self, buf: &DataStream) -> Result<bool, LoopExitReason> {
+        assert!(
+            buf.len() <= self.shrink_target.record.len(),
+            "Expected incorporate to not increase length, but buf.len() = {} \
+             while shrink target was {}",
+            buf.len(),
+            self.shrink_target.record.len()
+        );
+        if buf.len() == self.shrink_target.record.len() {
+            assert!(buf < &self.shrink_target.record);
+        }
+        if self.shrink_target.record.starts_with(buf) {
+            return Ok(false);
+        }
         let result = self.main_loop.execute(DataSource::from_vec(buf.clone()))?;
         return Ok(self.predicate(&result));
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -277,9 +277,12 @@ impl Engine {
             interesting_examples: 0,
         };
 
-        let handle = thread::spawn(move || {
-            main_loop.run();
-        });
+        let handle = thread::Builder::new()
+            .name("Hypothesis main loop".to_string())
+            .spawn(move || {
+                main_loop.run();
+            })
+            .unwrap();
 
         Engine {
             loop_response: None,


### PR DESCRIPTION
Usual one part the thing I went to add, 9 parts the things I noticed along the way debugging it!

This adds a very basic strings implementation. Handles unicode correctly, biased towards ascii.

Known issues:

* The way we check if we have a valid codepoint is probably super slow.
* The shrink order is weird. In hypothesis-python we rebias it towards '0' but I haven't done that here. Will do it post-alpha.