### PR TITLE
Add providers for hashes

### DIFF
--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -82,11 +82,24 @@ module Hypothesis
     end
   end
 
-  def given(*args, &block)
+  def given(*args)
     if World.current_engine.nil?
       raise UsageError, 'Cannot call given outside of a hypothesis block'
     end
-    World.current_engine.current_source.given(*args, &block)
+
+    @hypothesis_in_given = false unless defined? @hypothesis_in_given
+
+    if @hypothesis_in_given
+      raise UsageError, 'Cannot nest calls to given. Did you mean to call' \
+        ' given on a source argument?'
+    end
+
+    @hypothesis_in_given = true
+    begin
+      World.current_engine.current_source.given(*args)
+    ensure
+      @hypothesis_in_given = false
+    end
   end
 
   def assume(condition)

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -96,12 +96,6 @@ module Hypothesis
         core
       )
     end
-
-    def local_provider_implementation(&block)
-      Hypothesis::Provider::Implementations::ProviderFromBlock.new(
-        block
-      )
-    end
   end
 
   class Provider
@@ -143,16 +137,6 @@ module Hypothesis
           result = @core_provider.provide(data.wrapped_data)
           raise Hypothesis::DataOverflow if result.nil?
           result
-        end
-      end
-
-      class ProviderFromBlock < Provider
-        def initialize(block)
-          @block = block
-        end
-
-        def provide(data, &block)
-          @block.call(data, block)
         end
       end
     end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -23,6 +23,32 @@ module Hypothesis
       end
     end
 
+    def fixed_hashes(hash)
+      composite do |source|
+        result = {}
+        hash.each { |k, v| result[k] = source.given(v) }
+        result
+      end
+    end
+
+    def hashes(keys, values, min_size: 0, max_size: 10)
+      composite do |source|
+        result = {}
+        rep = HypothesisCoreRepeatValues.new(
+          min_size, max_size, (min_size + max_size) * 0.5
+        )
+        while rep.should_continue(source)
+          key = source.given(keys)
+          if result.include?(key)
+            rep.reject
+          else
+            result[key] = source.given(values)
+          end
+        end
+        result
+      end
+    end
+
     def strings(codepoints: nil, min_size: 0, max_size: 10)
       codepoints = self.codepoints if codepoints.nil?
       codepoints = codepoints.select do |i|

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -84,7 +84,7 @@ module Hypothesis
         if min.zero?
           bounded
         else
-          composite { |_source| min + given(bounded) }
+          composite { |source| min + source.given(bounded) }
         end
       end
     end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -64,6 +64,13 @@ module Hypothesis
       end
     end
 
+    def fixed_arrays(*elements)
+      elements = elements.flatten
+      composite do |source|
+        elements.map { |e| source.given(e) }.to_a
+      end
+    end
+
     def arrays(element, min_size: 0, max_size: 10)
       composite do |source|
         result = []

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -25,7 +25,7 @@ module Hypothesis
           false
         end
       end
-      lists(codepoints, min_size: min_size, max_size: max_size).map do |ls|
+      arrays(codepoints, min_size: min_size, max_size: max_size).map do |ls|
         ls.pack('U*')
       end
     end
@@ -39,7 +39,7 @@ module Hypothesis
       end
     end
 
-    def lists(element, min_size: 0, max_size: 10)
+    def arrays(element, min_size: 0, max_size: 10)
       composite do
         result = []
         given repeated(

--- a/spec/arrays_spec.rb
+++ b/spec/arrays_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe 'fixed arrays' do
+  they 'are of fixed size and shape' do
+    hypothesis do
+      ls = given fixed_arrays(integers, strings, integers)
+      expect(ls.size).to eq(3)
+      expect(ls[0]).to be_a(Integer)
+      expect(ls[2]).to be_a(Integer)
+      expect(ls[1]).to be_a(String)
+    end
+  end
+end

--- a/spec/bad_usage_spec.rb
+++ b/spec/bad_usage_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe 'Incorrect usage' do
       end
     end
   end
+
+  it 'includes using the parent given inside a composite' do
+    bad_usage do
+      hypothesis do
+        given(composite do
+          given integers
+        end)
+      end
+    end
+  end
 end

--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'fixed hash providers' do
+  they 'include all the keys' do
+    hypothesis do
+      x = given fixed_hashes(a: integers, b: integers)
+      expect(x.size).to eq(2)
+      expect(x[:a]).to be_a(Integer)
+      expect(x[:b]).to be_a(Integer)
+    end
+  end
+end
+
+RSpec.describe 'variable hash providers' do
+  they 'respect lower bounds' do
+    hypothesis do
+      x = given hashes(integers(min: 0, max: 4), strings, min_size: 4)
+      expect(x.size).to be >= 4
+    end
+  end
+end

--- a/spec/provided_list_spec.rb
+++ b/spec/provided_list_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'shrinking' do
   include Hypothesis::Providers
 
   it 'finds a small list' do
-    ls, = find { given(lists(integers)).length >= 2 }
+    ls, = find { given(arrays(integers)).length >= 2 }
     expect(ls).to eq([0, 0])
   end
 
@@ -13,7 +13,7 @@ RSpec.describe 'shrinking' do
     @original_target = nil
 
     ls, = find do
-      v = given(lists(integers))
+      v = given(arrays(integers))
 
       if v.length >= 5 && @original_target.nil? && v[-1] > 0
         @original_target = v

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -58,23 +58,27 @@ impl Repeat {
         }
     }
 
+    pub fn reject(&mut self) {
+        assert!(self.current_count > 0);
+        self.current_count -= 1;
+    }
+
     pub fn should_continue(&mut self, source: &mut DataSource) -> Result<bool, FailedDraw> {
-        let result = if self.current_count < self.min_count {
+        if self.current_count < self.min_count {
             self.draw_until(source, true)?;
             self.current_count += 1;
             return Ok(true);
         } else if self.current_count >= self.max_count {
             self.draw_until(source, false)?;
             return Ok(false);
-        } else {
-            weighted(source, self.p_continue)
-        };
-
-        match result {
-            Ok(true) => self.current_count += 1,
-            _ => (),
         }
-        return result;
+
+        let result = weighted(source, self.p_continue)?;
+        if result {
+            self.current_count += 1;
+        } else {
+        }
+        return Ok(result);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ ruby! {
       }
     }
 
-    def should_continue(&mut self, data: &mut HypothesisCoreDataSource) -> Option<bool>{
+    def _should_continue(&mut self, data: &mut HypothesisCoreDataSource) -> Option<bool>{
       return data.source.as_mut().and_then(|ref mut source| {
         self.repeat.should_continue(source).ok()
       })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,10 @@ ruby! {
         self.repeat.should_continue(source).ok()
       })
     }
+
+    def reject(&mut self){
+      self.repeat.reject();
+    }
   }
 
   class HypothesisCoreIntegers{


### PR DESCRIPTION
Also:

* Adds `fixed_arrays` (corresponding to python version's `tuples`) to match `fixed_hashes`.
* Fix a bug where `HypothesisCoreRepeatValues` did the wrong thing when the underlying buffer overran (it returned nil, which was falsey)
* Remove `repeated`. It's a bit of a weird API and I think I'd rather decided later if we want that.
* Make it an error to call `given` on self inside a `composite`. We can add it back later if needs be, but it makes for very weird control flow and basically only works when you're including both `Hypothesis` and `Hypothesis::Providers`. It should either always work or always be an error.
* Rename `lists` to `arrays` because Ruby