### PR TITLE
More API golfing for readability

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,14 +23,14 @@ RSpec.describe "removing an element from a list" do
     hypothesis do
       # Or lists(integers, min_size: 1), but this lets us
       # demonstrate assume.
-      values = given arrays(of: integers)
+      values = any array(of: integers)
 
       # If this is not true then the test will stop here.
       assume values.length > 0
 
       # note: choice_of is not currently implemented, but
       # would provide any value chosen from its argument.
-      to_remove = given(any_value_from(values))
+      to_remove = any choice_of(values)
 
       values.delete_at(value.index(to_remove))
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -41,7 +41,7 @@ for Python and Hypothesis for Ruby are:
 * Many of the providers have different names than the corresponding
   names in hypothesis-python. There is also a weird dual naming
   convention for providers where there is both e.g. `integers` and
-  `any_integer` as aliases for each other.
+  `integer` as aliases for each other.
 
 So for example:
 
@@ -49,8 +49,8 @@ So for example:
 RSPec.describe "integer addition" do
   it "commutes" do
     hypothesis do
-      m = given any_integer
-      n = given any_integer
+      m = any integer
+      n = any integer
       expect(m + n).to eq(n + m)
     end
   end

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -21,7 +21,7 @@ module Hypothesis
 
   # @!visibility private
   def hypothesis_stable_identifier
-    # Attempt to get a "stable identifier" for any given
+    # Attempt to get a "stable identifier" for any any
     # call into hypothesis. We use these to create
     # database keys (or will when we have a database) that
     # are stable across runs, so that when a test that
@@ -87,13 +87,13 @@ module Hypothesis
   #
   # ```ruby
   # hypothesis do
-  #   x = given any_integer
-  #   y = given any_integer(min: x)
+  #   x = any integer
+  #   y = any integer(min: x)
   #   expect(y).to be >= x
   # end
   # ```
   #
-  # The arguments to `given` are `Provider` instances which
+  # The arguments to `any` are `Provider` instances which
   # specify the range of value values for it to return.
   #
   # Typically you would include this inside some test in your
@@ -190,25 +190,25 @@ module Hypothesis
   # @param name [String, nil] An optional name to show next to the result on
   #   failure. This can be helpful if you have a lot of givens in your
   #   hypothesis, as it makes it easier to keep track of which is which.
-  def given(provider, name: nil)
+  def any(provider, name: nil)
     if World.current_engine.nil?
-      raise UsageError, 'Cannot call given outside of a hypothesis block'
+      raise UsageError, 'Cannot call any outside of a hypothesis block'
     end
 
-    @hypothesis_in_given = false unless defined? @hypothesis_in_given
+    @hypothesis_in_any = false unless defined? @hypothesis_in_any
 
-    if @hypothesis_in_given
-      raise UsageError, 'Cannot nest calls to given. Did you mean to call' \
-        ' given on a source argument?'
+    if @hypothesis_in_any
+      raise UsageError, 'Cannot nest calls to any. Did you mean to call' \
+        ' any on a source argument?'
     end
 
-    @hypothesis_in_given = true
+    @hypothesis_in_any = true
     begin
-      World.current_engine.current_source.internal_given(
+      World.current_engine.current_source.internal_any(
         provider, name: name
       )
     ensure
-      @hypothesis_in_given = false
+      @hypothesis_in_any = false
     end
   end
 

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -153,7 +153,7 @@ module Hypothesis
     def codepoints(min: 1, max: 1_114_111)
       base = integers(min: min, max: max)
       if min <= 126
-        mixed(integers(min: min, max: [126, max].min), base)
+        from(integers(min: min, max: [126, max].min), base)
       else
         base
       end
@@ -279,14 +279,18 @@ module Hypothesis
 
     # A provider that combines several other providers, so that it may
     # provide any value that could come from one of them.
-    # For example, mixed(strings, integers) could provide either of "a"
+    # For example, from(strings, integers) could provide either of "a"
     # or 1.
+    # @note This has a slightly non-standard aliasing. It reads more
+    #   nicely if you write `any from(a, b, c)` but e.g.
+    #   `lists(of: mix_of(a, b, c))`.
+    #
     # @return [Provider]
     # @param components [Array<Provider>] Providers from which the
     #   returned provider may draw values. If components contains an
-    #   array it will be flattened first, so e.g. mixed(a, b)
-    #   is equivalent to mixed([a, b])
-    def mixed(*components)
+    #   array it will be flattened first, so e.g. from(a, b)
+    #   is equivalent to from([a, b])
+    def from(*components)
       components = components.flatten
       indexes = from_hypothesis_core(
         HypothesisCoreBoundedIntegers.new(components.size - 1)
@@ -296,6 +300,8 @@ module Hypothesis
         source.any(components[i])
       end
     end
+
+    alias mix_of from
 
     # A provider for any one of a fixed list of values.
     # @note these values are provided as is, so if the provided

--- a/lib/hypothesis/testcase.rb
+++ b/lib/hypothesis/testcase.rb
@@ -18,15 +18,15 @@ module Hypothesis
       @depth = 0
     end
 
-    # Calls {Hypothesis#given} in the test case this represents,
+    # Calls {Hypothesis#any} in the test case this represents,
     # but does not print the result in the event of a failing test
     # case.
     #
-    # @return [Object] A given for the current test case.
+    # @return [Object] A any for the current test case.
     # @param provider [Provider] A provider describing the possible
-    #   givens.
-    def given(provider)
-      internal_given(provider)
+    #   anys.
+    def any(provider)
+      internal_any(provider)
     end
 
     # Calls {Hypothesis#assume} in the test case this represents.
@@ -35,7 +35,7 @@ module Hypothesis
     end
 
     # @!visibility private
-    def internal_given(provider = nil, name: nil, &block)
+    def internal_any(provider = nil, name: nil, &block)
       top_level = @depth.zero?
 
       begin

--- a/spec/arrays_spec.rb
+++ b/spec/arrays_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe 'fixed arrays' do
   they 'are of fixed size and shape' do
     hypothesis do
-      ls = given any_array_of_shape(
-        any_integer, any_string, any_integer
+      ls = any array_of_shape(
+        integer, string, integer
       )
       expect(ls.size).to eq(3)
       expect(ls[0]).to be_a(Integer)

--- a/spec/bad_usage_spec.rb
+++ b/spec/bad_usage_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Incorrect usage' do
     end
   end
 
-  it 'includes using given outside a hypothesis call' do
-    bad_usage { given integers }
+  it 'includes using any outside a hypothesis call' do
+    bad_usage { any integers }
   end
 
   it 'includes using assume outside a hypothesis call' do
@@ -28,16 +28,16 @@ RSpec.describe 'Incorrect usage' do
     end
     bad_usage do
       hypothesis do
-        find { given integers >= 0 }
+        find { any integers >= 0 }
       end
     end
   end
 
-  it 'includes using the parent given inside a composite' do
+  it 'includes using the parent any inside a composite' do
     bad_usage do
       hypothesis do
-        given(composite do
-          given integers
+        any(composite do
+          any integers
         end)
       end
     end

--- a/spec/basic_examples_spec.rb
+++ b/spec/basic_examples_spec.rb
@@ -7,8 +7,8 @@ end
 RSpec.describe 'basic hypothesis tests' do
   they 'think integer addition is commutative' do
     hypothesis do
-      x = given integers
-      y = given integers
+      x = any integers
+      y = any integers
       expect(x + y).to eq(y + x)
     end
   end
@@ -16,7 +16,7 @@ RSpec.describe 'basic hypothesis tests' do
   they 'are able to find zero values' do
     expect_failure do
       hypothesis do
-        x = given integers
+        x = any integers
         expect(x).not_to eq(0)
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe 'basic hypothesis tests' do
 
   they 'are able to filter out values' do
     hypothesis do
-      x = given integers
+      x = any integers
       assume x != 0
       1 / x
     end
@@ -33,8 +33,8 @@ RSpec.describe 'basic hypothesis tests' do
   they 'find that string addition is not commutative' do
     expect_failure do
       hypothesis do
-        x = given strings
-        y = given strings
+        x = any strings
+        y = any strings
         expect(x + y).to be == y + x
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe 'basic hypothesis tests' do
   they 'raise unsatisfiable when all assumptions fail' do
     expect do
       hypothesis do
-        given integers
+        any integers
         assume false
       end
     end.to raise_exception(Hypothesis::Unsatisfiable)

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe 'booleans' do
   include Hypothesis::Debug
 
   they 'can be true' do
-    find_any { given booleans }
+    find_any { any booleans }
   end
 
   they 'can be false' do
-    find_any { !given(booleans) }
+    find_any { !any(booleans) }
   end
 end

--- a/spec/choice_spec.rb
+++ b/spec/choice_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'choice_of provider' do
 
   it 'includes the first argument' do
     find_any do
-      m = given any_value_from([0, 1])
+      m = any choice_from([0, 1])
       m == 0
     end
   end
 
   it 'includes the last argument' do
     find_any do
-      m = given any_value_from([0, 1, 2, 3])
+      m = any choice_from([0, 1, 2, 3])
       m == 3
     end
   end

--- a/spec/debug_spec.rb
+++ b/spec/debug_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'find' do
   it "raises an error if it can't find anything" do
     expect do
       find do
-        given integers
+        any integers
         false
       end
     end.to raise_exception(Hypothesis::Debug::NoSuchExample)

--- a/spec/example_discovery_spec.rb
+++ b/spec/example_discovery_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'hypothesis' do
 
   it 'can find mid sized integers' do
     n, = find do
-      m = given(integers)
+      m = any(integers)
       m >= 100 && m <= 1000
     end
     expect(n).to eq(100)

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'printing examples' do
   it 'adds a statement to the exceptions string' do
     expect do
       hypothesis do
-        n = given integers
+        n = any integers
         expect(n).to eq(0)
       end
     end.to raise_exception(/Given #1/)
@@ -13,8 +13,8 @@ RSpec.describe 'printing examples' do
   it 'adds multiple statements to the exceptions string' do
     expect do
       hypothesis do
-        n = given integers
-        m = given integers
+        n = any integers
+        m = any integers
         expect(n).to eq(m)
       end
     end.to raise_exception(/Given #1.+Given #2/m)
@@ -23,7 +23,7 @@ RSpec.describe 'printing examples' do
   it 'includes the name in the Given' do
     expect do
       hypothesis do
-        n = given integers, name: 'fred'
+        n = any integers, name: 'fred'
         expect(n).to eq(1)
       end
     end.to raise_exception(/Given fred:/)
@@ -34,7 +34,7 @@ RSpec.describe 'printing examples' do
     3.times do
       expect do
         hypothesis do
-          given integers
+          any integers
           raise shared
         end
       end.to raise_exception do |ex|
@@ -45,13 +45,13 @@ RSpec.describe 'printing examples' do
     end
   end
 
-  it 'does not include nested givens in printing' do
+  it 'does not include nested anys in printing' do
     expect do
       hypothesis do
-        value = given(composite do |source|
-          source.given integers
-          source.given integers
-          source.given integers
+        value = any(composite do |source|
+          source.any integers
+          source.any integers
+          source.any integers
         end)
         expect(value).to eq(0)
       end
@@ -63,7 +63,7 @@ RSpec.describe 'printing examples' do
   it 'includes Given in inspect as well as to_s' do
     expect do
       hypothesis do
-        n = given integers
+        n = any integers
         expect(n).to eq(0)
       end
     end.to raise_exception do |ex|

--- a/spec/example_shrinking_spec.rb
+++ b/spec/example_shrinking_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'shrinking' do
   include Hypothesis::Debug
 
   it 'finds lower bounds on integers' do
-    n, = find { given(integers) >= 10 }
+    n, = find { any(integers) >= 10 }
     expect(n).to eq(10)
   end
 
@@ -12,8 +12,8 @@ RSpec.describe 'shrinking' do
     @original = nil
 
     a, b = find do
-      m = given integers
-      n = given integers
+      m = any integers
+      n = any integers
       m > n && n > 0
     end
 

--- a/spec/hashes_spec.rb
+++ b/spec/hashes_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'fixed hash providers' do
   they 'include all the keys' do
     hypothesis do
-      x = given any_hash_of_shape(a: integers, b: integers)
+      x = any hash_of_shape(a: integers, b: integers)
       expect(x.size).to eq(2)
       expect(x[:a]).to be_a(Integer)
       expect(x[:b]).to be_a(Integer)
@@ -14,7 +14,7 @@ end
 RSpec.describe 'variable hash providers' do
   they 'respect lower bounds' do
     hypothesis do
-      x = given any_hash_with(
+      x = any hash_with(
         keys: integers(min: 0, max: 4),
         values: strings,
         min_size: 4

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -3,19 +3,19 @@
 RSpec.describe 'integer providers' do
   they 'respect upper bounds' do
     hypothesis do
-      expect(given(integers(max: 100))).to be <= 100
+      expect(any(integers(max: 100))).to be <= 100
     end
   end
 
   they 'respect lower bounds' do
     hypothesis do
-      expect(given(integers(min: -100))).to be >= -100
+      expect(any(integers(min: -100))).to be >= -100
     end
   end
 
   they 'respect both bounds at once when lower bound is zero' do
     hypothesis do
-      n = given integers(min: 0, max: 100)
+      n = any integers(min: 0, max: 100)
       expect(n).to be <= 100
       expect(n).to be >= 0
     end
@@ -23,7 +23,7 @@ RSpec.describe 'integer providers' do
 
   they 'respect both bounds at once when lower bound is non-zero' do
     hypothesis do
-      n = given integers(min: 1, max: 100)
+      n = any integers(min: 1, max: 100)
       expect(n).to be <= 100
       expect(n).to be >= 1
     end

--- a/spec/mixing_spec.rb
+++ b/spec/mixing_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-RSpec.describe 'mixed provider' do
+RSpec.describe 'from provider' do
   include Hypothesis::Debug
 
   it 'includes the first argument' do
     find_any do
-      any(mixed(integers, strings)).is_a? Integer
+      any(from(integers, strings)).is_a? Integer
     end
   end
 
   it 'includes the second argument' do
     find_any do
-      any(mixed(integers, strings)).is_a? String
+      any(from(integers, strings)).is_a? String
     end
   end
 end

--- a/spec/mixing_spec.rb
+++ b/spec/mixing_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe 'mixed provider' do
 
   it 'includes the first argument' do
     find_any do
-      given(mixed(integers, strings)).is_a? Integer
+      any(mixed(integers, strings)).is_a? Integer
     end
   end
 
   it 'includes the second argument' do
     find_any do
-      given(mixed(integers, strings)).is_a? String
+      any(mixed(integers, strings)).is_a? String
     end
   end
 end

--- a/spec/provided_list_spec.rb
+++ b/spec/provided_list_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'shrinking' do
   include Hypothesis::Providers
 
   it 'finds a small list' do
-    ls, = find { given(arrays(of: integers)).length >= 2 }
+    ls, = find { any(arrays(of: integers)).length >= 2 }
     expect(ls).to eq([0, 0])
   end
 
@@ -13,7 +13,7 @@ RSpec.describe 'shrinking' do
     @original_target = nil
 
     ls, = find do
-      v = given(arrays(of: integers))
+      v = any(arrays(of: integers))
 
       if v.length >= 5 && @original_target.nil? && v[-1] > 0
         @original_target = v

--- a/spec/strings_spec.rb
+++ b/spec/strings_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'strings' do
   they 'respect a non-ascii lower bound' do
     hypothesis do
-      expect(given(codepoints(min: 127))).to be >= 127
+      expect(any(codepoints(min: 127))).to be >= 127
     end
   end
 end
@@ -13,20 +13,20 @@ RSpec.describe 'strings' do
 
   they 'can be ascii' do
     find_any do
-      s = given(strings(min_size: 3, max_size: 3))
+      s = any(strings(min_size: 3, max_size: 3))
       s.codepoints.all? { |c| c < 127 }
     end
   end
 
   they 'can be non-ascii' do
     find_any do
-      given(strings).codepoints.any? { |c| c > 127 }
+      any(strings).codepoints.any? { |c| c > 127 }
     end
   end
 
   they 'produce valid strings' do
     find do
-      s = given(strings)
+      s = any(strings)
       # Shrinking will try and fail to move this into
       # an invalid codepoint range.
       !s.empty? && s.codepoints[0] >= 56_785


### PR DESCRIPTION
When in Rome, do what the Romans do. When in Ruby, golf your API to a ridiculous degree in search of a natural language DSL...

Between suggestions from @jeremy-w (BTW @jeremy-w would you like to be on the team as a contributor?) and @hwayne I hit on the "great" idea that the method formerly known as given would look much better if it were named "any".

```ruby
hypothesis do
    ls = any list(of: integers)
    ...
end
```

It really reads a lot better I think.