### PR TITLE
A bunch of polishing of the API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ require "hypothesis"
 
 RSpec.configure do |config|
   config.include(Hypothesis)
-  config.include(Hypothesis::Providers)
+  config.include(Hypothesis::Possibilities)
 end
 
 RSpec.describe "removing an element from a list" do

--- a/README.markdown
+++ b/README.markdown
@@ -21,16 +21,14 @@ end
 RSpec.describe "removing an element from a list" do
   it "results in the element no longer being in the list" do
     hypothesis do
-      # Or lists(integers, min_size: 1), but this lets us
+      # Or lists(of: integers, min_size: 1), but this lets us
       # demonstrate assume.
       values = any array(of: integers)
 
       # If this is not true then the test will stop here.
-      assume values.length > 0
+      assume values.size > 0
 
-      # note: choice_of is not currently implemented, but
-      # would provide any value chosen from its argument.
-      to_remove = any choice_of(values)
+      to_remove = any element_of(values)
 
       values.delete_at(value.index(to_remove))
 

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ begin
   YARD::Rake::YardocTask.new(:runyard) do |t|
     t.files = [
       'lib/hypothesis.rb', 'lib/hypothesis/errors.rb',
-      'lib/hypothesis/providers.rb', 'lib/hypothesis/testcase.rb'
+      'lib/hypothesis/providers.rb'
     ]
     t.options = ['--markup=markdown', '--no-private']
   end

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -195,21 +195,9 @@ module Hypothesis
       raise UsageError, 'Cannot call any outside of a hypothesis block'
     end
 
-    @hypothesis_in_any = false unless defined? @hypothesis_in_any
-
-    if @hypothesis_in_any
-      raise UsageError, 'Cannot nest calls to any. Did you mean to call' \
-        ' any on a source argument?'
-    end
-
-    @hypothesis_in_any = true
-    begin
-      World.current_engine.current_source.internal_any(
-        provider, name: name
-      )
-    ensure
-      @hypothesis_in_any = false
-    end
+    World.current_engine.current_source.internal_any(
+      provider, name: name
+    )
   end
 
   # Specify an assumption of your test case. Only test cases which satisfy

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -195,7 +195,7 @@ module Hypothesis
       raise UsageError, 'Cannot call any outside of a hypothesis block'
     end
 
-    World.current_engine.current_source.internal_any(
+    World.current_engine.current_source.any(
       provider, name: name
     )
   end

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -190,13 +190,13 @@ module Hypothesis
   # @param name [String, nil] An optional name to show next to the result on
   #   failure. This can be helpful if you have a lot of givens in your
   #   hypothesis, as it makes it easier to keep track of which is which.
-  def any(provider, name: nil)
+  def any(provider, name: nil, &block)
     if World.current_engine.nil?
       raise UsageError, 'Cannot call any outside of a hypothesis block'
     end
 
     World.current_engine.current_source.any(
-      provider, name: name
+      provider, name: name, &block
     )
   end
 

--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -93,7 +93,7 @@ module Hypothesis
   # end
   # ```
   #
-  # The arguments to `any` are `Provider` instances which
+  # The arguments to `any` are `Possible` instances which
   # specify the range of value values for it to return.
   #
   # Typically you would include this inside some test in your
@@ -185,7 +185,7 @@ module Hypothesis
   # Supplies a value to be used in your hypothesis.
   # @note It is invalid to call this method outside of a hypothesis block.
   # @return [Object] A value provided by the provider argument.
-  # @param provider [Provider] A provider that specifies the possible values
+  # @param provider [Possible] A provider that specifies the possible values
   #   to return.
   # @param name [String, nil] An optional name to show next to the result on
   #   failure. This can be helpful if you have a lot of givens in your

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -120,14 +120,14 @@ module Hypothesis
       include Providers
     end
 
-    # composite lets you chain multiple providers together,
+    # built_as lets you chain multiple providers together,
     # by providing whatever value results from its block.
     #
     # For example the following provides a list plus some
     # element from that list:
     #
     # ```ruby
-    #   composite do
+    #   built_as do
     #     ls = any list(of: integers)
     #     # Or min_size: 1 above, but this shows use of
     #     # assume
@@ -138,9 +138,11 @@ module Hypothesis
     #
     # @return [Provider] A provider that provides the result
     #   of the passed block.
-    def composite(&block)
+    def built_as(&block)
       Hypothesis::Provider::Implementations::CompositeProvider.new(block)
     end
+
+    alias values_built_as built_as
 
     # A provider of boolean values
     # @return [Provider]
@@ -204,7 +206,7 @@ module Hypothesis
     #  and the values should be providers that will be used to provide
     #  the corresponding values.
     def hashes_of_shape(hash)
-      composite do
+      built_as do
         result = {}
         hash.each { |k, v| result[k] = any(v) }
         result
@@ -220,7 +222,7 @@ module Hypothesis
     # @param keys [Provider] the provider that will provide keys
     # @param values [Provider] the provider that will provide values
     def hashes_with(keys:, values:, min_size: 0, max_size: 10)
-      composite do
+      built_as do
         result = {}
         rep = HypothesisCoreRepeatValues.new(
           min_size, max_size, (min_size + max_size) * 0.5
@@ -253,7 +255,7 @@ module Hypothesis
     #   is equivalent to fixed_arrays([a, b])
     def arrays_of_shape(*elements)
       elements = elements.flatten
-      composite do
+      built_as do
         elements.map { |e| any e }.to_a
       end
     end
@@ -270,7 +272,7 @@ module Hypothesis
     # @param min_size [Integer] The smallest valid size of a provided array
     # @param max_size [Integer] The largest valid size of a provided array
     def arrays(of:, min_size: 0, max_size: 10)
-      composite do
+      built_as do
         result = []
         rep = HypothesisCoreRepeatValues.new(
           min_size, max_size, (min_size + max_size) * 0.5
@@ -301,7 +303,7 @@ module Hypothesis
       indexes = from_hypothesis_core(
         HypothesisCoreBoundedIntegers.new(components.size - 1)
       )
-      composite do
+      built_as do
         i = any indexes
         any components[i]
       end
@@ -324,7 +326,7 @@ module Hypothesis
       indexes = from_hypothesis_core(
         HypothesisCoreBoundedIntegers.new(values.size - 1)
       )
-      composite do
+      built_as do
         values.fetch(any(indexes))
       end
     end
@@ -340,9 +342,9 @@ module Hypothesis
       if min.nil? && max.nil?
         base
       elsif min.nil?
-        composite { max - any(base).abs }
+        built_as { max - any(base).abs }
       elsif max.nil?
-        composite { min + any(base).abs }
+        built_as { min + any(base).abs }
       else
         bounded = from_hypothesis_core(
           HypothesisCoreBoundedIntegers.new(max - min)
@@ -350,7 +352,7 @@ module Hypothesis
         if min.zero?
           bounded
         else
-          composite { min + any(bounded) }
+          built_as { min + any(bounded) }
         end
       end
     end

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -76,8 +76,8 @@ module Hypothesis
         end
 
         # @!visibility private
-        def provide
-          @block.call
+        def provide(&block)
+          (@block || block).call
         end
       end
 
@@ -131,7 +131,7 @@ module Hypothesis
     #     ls = any list(of: integers)
     #     # Or min_size: 1 above, but this shows use of
     #     # assume
-    #     assume(ls.size > 0)
+    #     assume ls.size > 0
     #     i = any element_of(ls)
     #     [ls, i]
     # ```

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -76,7 +76,7 @@ module Hypothesis
         end
 
         # @!visibility private
-        def provide(_source)
+        def provide
           @block.call
         end
       end
@@ -88,7 +88,8 @@ module Hypothesis
         end
 
         # @!visibility private
-        def provide(data)
+        def provide
+          data = World.current_engine.current_source
           result = @core_provider.provide(data.wrapped_data)
           raise Hypothesis::DataOverflow if result.nil?
           result

--- a/lib/hypothesis/providers.rb
+++ b/lib/hypothesis/providers.rb
@@ -126,7 +126,7 @@ module Hypothesis
     #     # Or min_size: 1 above, but this shows use of
     #     # assume
     #     tc.assume(ls.size > 0)
-    #     i = tc.any(choice_of(ls))
+    #     i = tc.any(element_of(ls))
     #     [ls, i]
     # ```
     #
@@ -313,7 +313,7 @@ module Hypothesis
     # @return [Provider]
     # @param values [Enumerable] A collection of values that may be
     #   provided.
-    def choice_from(values)
+    def element_of(values)
       values = values.to_a
       indexes = from_hypothesis_core(
         HypothesisCoreBoundedIntegers.new(values.size - 1)
@@ -323,7 +323,7 @@ module Hypothesis
       end
     end
 
-    alias choices_from choice_from
+    alias elements_of element_of
 
     # A provider for integers
     # @return [Provider]

--- a/lib/hypothesis/testcase.rb
+++ b/lib/hypothesis/testcase.rb
@@ -5,6 +5,7 @@ module Hypothesis
   # an executing test case. You do not normally need to use this
   # within the body of the test, but it exists to be used as
   # an argument to {Hypothesis::Providers::composite}.
+  # @!visibility private
   class TestCase
     # @!visibility private
     attr_reader :draws, :print_log, :print_draws, :wrapped_data
@@ -18,30 +19,18 @@ module Hypothesis
       @depth = 0
     end
 
-    # Calls {Hypothesis#any} in the test case this represents,
-    # but does not print the result in the event of a failing test
-    # case.
-    #
-    # @return [Object] A any for the current test case.
-    # @param provider [Provider] A provider describing the possible
-    #   anys.
-    def any(provider)
-      internal_any(provider)
-    end
-
-    # Calls {Hypothesis#assume} in the test case this represents.
     def assume(condition)
       raise UnsatisfiedAssumption unless condition
     end
 
     # @!visibility private
-    def internal_any(provider = nil, name: nil, &block)
+    def any(provider = nil, name: nil, &block)
       top_level = @depth.zero?
 
       begin
         @depth += 1
         provider ||= block
-        result = provider.provide(self, &block)
+        result = provider.provide
         if top_level
           draws&.push(result)
           print_log&.push([name, result.inspect])

--- a/lib/hypothesis/testcase.rb
+++ b/lib/hypothesis/testcase.rb
@@ -4,7 +4,7 @@ module Hypothesis
   # A TestCase class provides a concrete representation of
   # an executing test case. You do not normally need to use this
   # within the body of the test, but it exists to be used as
-  # an argument to {Hypothesis::Providers::built_as}.
+  # an argument to {Hypothesis::Possibilities::built_as}.
   # @!visibility private
   class TestCase
     # @!visibility private

--- a/lib/hypothesis/testcase.rb
+++ b/lib/hypothesis/testcase.rb
@@ -30,7 +30,7 @@ module Hypothesis
       begin
         @depth += 1
         provider ||= block
-        result = provider.provide
+        result = provider.provide(&block)
         if top_level
           draws&.push(result)
           print_log&.push([name, result.inspect])

--- a/lib/hypothesis/testcase.rb
+++ b/lib/hypothesis/testcase.rb
@@ -4,7 +4,7 @@ module Hypothesis
   # A TestCase class provides a concrete representation of
   # an executing test case. You do not normally need to use this
   # within the body of the test, but it exists to be used as
-  # an argument to {Hypothesis::Providers::composite}.
+  # an argument to {Hypothesis::Providers::built_as}.
   # @!visibility private
   class TestCase
     # @!visibility private

--- a/spec/bad_usage_spec.rb
+++ b/spec/bad_usage_spec.rb
@@ -32,14 +32,4 @@ RSpec.describe 'Incorrect usage' do
       end
     end
   end
-
-  it 'includes using the parent any inside a composite' do
-    bad_usage do
-      hypothesis do
-        any(composite do
-          any integers
-        end)
-      end
-    end
-  end
 end

--- a/spec/choice_spec.rb
+++ b/spec/choice_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.describe 'choice_of provider' do
+RSpec.describe 'element_of provider' do
   include Hypothesis::Debug
 
   it 'includes the first argument' do
     find_any do
-      m = any choice_from([0, 1])
+      m = any element_of([0, 1])
       m == 0
     end
   end
 
   it 'includes the last argument' do
     find_any do
-      m = any choice_from([0, 1, 2, 3])
+      m = any element_of([0, 1, 2, 3])
       m == 3
     end
   end

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe 'printing examples' do
   it 'does not include nested anys in printing' do
     expect do
       hypothesis do
-        value = any(composite do
+        value = any composite do
           any integers
           any integers
           any integers
-        end)
+        end
         expect(value).to eq(0)
       end
     end.to raise_exception(RSpec::Expectations::ExpectationNotMetError) do |ex|

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'printing examples' do
   it 'does not include nested anys in printing' do
     expect do
       hypothesis do
-        value = any composite do
+        value = any built_as do
           any integers
           any integers
           any integers

--- a/spec/example_printing_spec.rb
+++ b/spec/example_printing_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe 'printing examples' do
   it 'does not include nested anys in printing' do
     expect do
       hypothesis do
-        value = any(composite do |source|
-          source.any integers
-          source.any integers
-          source.any integers
+        value = any(composite do
+          any integers
+          any integers
+          any integers
         end)
         expect(value).to eq(0)
       end

--- a/spec/provided_list_spec.rb
+++ b/spec/provided_list_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'shrinking' do
   include Hypothesis::Debug
-  include Hypothesis::Providers
+  include Hypothesis::Possibilities
 
   it 'finds a small list' do
     ls, = find { any(arrays(of: integers)).length >= 2 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,5 +69,5 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.include(Hypothesis)
-  config.include(Hypothesis::Providers)
+  config.include(Hypothesis::Possibilities)
 end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,13 @@ ruby! {
     }
   }
 
-  class HypothesisCoreBitProvider{
+  class HypothesisCoreBitPossible{
     struct {
       n_bits: u64,
     }
 
     def initialize(helix, n_bits: u64){
-      return HypothesisCoreBitProvider{helix, n_bits: n_bits};
+      return HypothesisCoreBitPossible{helix, n_bits: n_bits};
     }
 
     def provide(&mut self, data: &mut HypothesisCoreDataSource) -> Option<u64>{


### PR DESCRIPTION
This introduces a number of changes to the API to attempt to make it read better.

Notably differences:

* `composite` is now called `built_as`
* providers now just read the test case from global state. This significantly improves the readability of `built_as`
* Restores passing the block to the `provide` method  so that use of `built_as` inline doesn't require brackets. 
* `Providers` are now called `Possible`
* Timelines go sideways now
* Likes are florps