### PR TITLE
Automate updating of changelog and version in releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ jobs:
       env: TASK=run-tests
       script: ./scripts/run-tests-isolated.sh
     - stage: deploy
-
+      if: branch = master
       script: bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,13 @@ install:
 jobs:
   include:
     - stage: test
+      env: TASK=checkformat
       script: bundle exec rake checkformat
     -
+      env: TASK=documentation
       script: bundle exec rake doc
     -
+      env: TASK=run-tests
       script: ./scripts/run-tests-isolated.sh
     - stage: deploy
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This is a trivial release to test the release automation.
+It should have no user visible impact.


### PR DESCRIPTION
In *highly unexpected news*, it turns out that in order to get releasing working to my satisfaction I had to throw away all of the Travis deploy infrastructure and write my own based on the hypothesis-python infrastructure.

Given that I had to do that *anyway*, it wasn't much extra work to get a similar release file mechanism up and running. There's enough different that this ended up being a recreation rather than a reuse, but very much the same idea: There is a `RELEASE.md` file in the root of the repo, and this updates the associated version and date of the gemspec and then adds it to the `CHANGELOG.md`.

Fixes #31.